### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install go
 ## Installation
 
 ```
-go get github.com/pivotal-cf-experimental/bosh-bootloader/...
+go get github.com/pivotal-cf-experimental/bosh-bootloader/bbl
 ```
 
 ## Usage


### PR DESCRIPTION
only go-get the `bbl` program itself

incredibly, you only need to get the `bbl` program, and the go get will grab the vendor submodules as needed.
